### PR TITLE
RDKEMW-17712 : Ignore error on mounted version file on overlayfs build

### DIFF
--- a/src/rdkversion.cpp
+++ b/src/rdkversion.cpp
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <string>
 #include <sys/stat.h>
+#include <sys/vfs.h>
 #include "rdkversion.h"
 
 using namespace std;
@@ -37,6 +38,12 @@ using namespace std;
 #define VERSION_TAG_JENKINS_JOB          "JENKINS_JOB="
 #define VERSION_TAG_JENKINS_BUILD_NUMBER "JENKINS_BUILD_NUMBER="
 #define VERSION_TAG_BUILD_TIME           "BUILD_TIME="
+
+
+#ifndef OVERLAYFS_SUPER_MAGIC
+#define OVERLAYFS_SUPER_MAGIC 0x794c7630
+#endif
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -81,8 +88,20 @@ unsigned char rdk_version_parse_version(rdk_version_info_t *version_info) {
       int rc_dir  = stat(VERSION_TXT_DIR, &statbuf_dir);
       int rc_path = stat(VERSION_TXT_PATH, &statbuf_path);
 
-      // The file is a mount point if the st_dev field returned by stat is different from its directory.
-      if(rc_dir != 0 || rc_path != 0 || statbuf_path.st_dev != statbuf_dir.st_dev) {
+      bool mounted = false;
+
+      if (rc_dir == 0 && rc_path == 0) {
+          struct statfs fs;
+          if (statfs(VERSION_TXT_DIR, &fs) == 0) {
+              if (fs.f_type != OVERLAYFS_SUPER_MAGIC) {
+                  // keep original behaviour for non-overlay filesystems
+                  mounted = (statbuf_path.st_dev != statbuf_dir.st_dev);
+              }
+              // else: overlayfs → ignore st_dev comparison
+          }
+      }
+
+      if (rc_dir != 0 || rc_path != 0 || mounted) {
          if(rc_dir != 0) {
             parse_error_ = "Unable to stat <" VERSION_TXT_DIR ">";
          } else if(rc_path != 0) {

--- a/src/rdkversion.cpp
+++ b/src/rdkversion.cpp
@@ -76,11 +76,9 @@ unsigned char rdk_version_parse_version(rdk_version_info_t *version_info) {
       parse_error_ = "Empty " VERSION_TXT_PATH " file";
       ret_val = 1;
    } else {
-      struct stat statbuf_dir;
       struct stat statbuf_path;
       struct stat overlay_stat;
 
-      int rc_dir  = stat(VERSION_TXT_DIR, &statbuf_dir);
       int rc_path = stat(VERSION_TXT_PATH, &statbuf_path);
       int rc_overlayfs_path = stat(OVERLAYFS_TAG_PATH, &overlay_stat);
 
@@ -95,7 +93,8 @@ unsigned char rdk_version_parse_version(rdk_version_info_t *version_info) {
          parse_version_contents = true;
       } else {
          // check for mounted file
-         rc_dir = stat(VERSION_TXT_DIR, &statbuf_dir);
+         struct stat statbuf_dir;
+         int rc_dir = stat(VERSION_TXT_DIR, &statbuf_dir);
          if(rc_dir != 0 || statbuf_path.st_dev != statbuf_dir.st_dev) {
             if(rc_dir != 0) {
                parse_error_ = "Unable to stat <" VERSION_TXT_DIR ">";

--- a/src/rdkversion.cpp
+++ b/src/rdkversion.cpp
@@ -23,7 +23,6 @@
 #include <string.h>
 #include <string>
 #include <sys/stat.h>
-#include <sys/vfs.h>
 #include "rdkversion.h"
 
 using namespace std;
@@ -38,12 +37,7 @@ using namespace std;
 #define VERSION_TAG_JENKINS_JOB          "JENKINS_JOB="
 #define VERSION_TAG_JENKINS_BUILD_NUMBER "JENKINS_BUILD_NUMBER="
 #define VERSION_TAG_BUILD_TIME           "BUILD_TIME="
-
-
-#ifndef OVERLAYFS_SUPER_MAGIC
-#define OVERLAYFS_SUPER_MAGIC 0x794c7630
-#endif
-
+#define OVERLAYFS_TAG_PATH               "/etc/overlay-init"
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,24 +78,14 @@ unsigned char rdk_version_parse_version(rdk_version_info_t *version_info) {
    } else {
       struct stat statbuf_dir;
       struct stat statbuf_path;
+      struct stat overlay_stat;
 
       int rc_dir  = stat(VERSION_TXT_DIR, &statbuf_dir);
       int rc_path = stat(VERSION_TXT_PATH, &statbuf_path);
+      int overlayfs_path = stat(OVERLAYFS_TAG_PATH, &overlay_stat);
 
-      bool mounted = false;
-
-      if (rc_dir == 0 && rc_path == 0) {
-          struct statfs fs;
-          if (statfs(VERSION_TXT_DIR, &fs) == 0) {
-              if (fs.f_type != OVERLAYFS_SUPER_MAGIC) {
-                  // keep original behaviour for non-overlay filesystems
-                  mounted = (statbuf_path.st_dev != statbuf_dir.st_dev);
-              }
-              // else: overlayfs → ignore st_dev comparison
-          }
-      }
-
-      if (rc_dir != 0 || rc_path != 0 || mounted) {
+      // The file is a mount point if the st_dev field returned by stat is different from its directory.
+      if(rc_dir != 0 || rc_path != 0 || (overlayfs_path != 0 && statbuf_path.st_dev != statbuf_dir.st_dev)) {
          if(rc_dir != 0) {
             parse_error_ = "Unable to stat <" VERSION_TXT_DIR ">";
          } else if(rc_path != 0) {

--- a/src/rdkversion.cpp
+++ b/src/rdkversion.cpp
@@ -82,19 +82,33 @@ unsigned char rdk_version_parse_version(rdk_version_info_t *version_info) {
 
       int rc_dir  = stat(VERSION_TXT_DIR, &statbuf_dir);
       int rc_path = stat(VERSION_TXT_PATH, &statbuf_path);
-      int overlayfs_path = stat(OVERLAYFS_TAG_PATH, &overlay_stat);
+      int rc_overlayfs_path = stat(OVERLAYFS_TAG_PATH, &overlay_stat);
 
-      // The file is a mount point if the st_dev field returned by stat is different from its directory.
-      if(rc_dir != 0 || rc_path != 0 || (overlayfs_path != 0 && statbuf_path.st_dev != statbuf_dir.st_dev)) {
-         if(rc_dir != 0) {
-            parse_error_ = "Unable to stat <" VERSION_TXT_DIR ">";
-         } else if(rc_path != 0) {
-            parse_error_ = "Unable to stat <" VERSION_TXT_PATH ">";
-         } else {
-            parse_error_ = "version file is mounted";
-         }
+      // The mounted file check is only needed when overlayfs is not enabled. If overlayfs is enabled, the check needs to be skipped.
+      bool parse_version_contents = false;
+
+      if(rc_path != 0) {
+         parse_error_ = "Unable to stat <" VERSION_TXT_PATH ">";
          ret_val = 1;
+      } else if(rc_overlayfs_path == 0) {
+         // skip mounted file check when overlayfs is enabled
+         parse_version_contents = true;
       } else {
+         // check for mounted file
+         rc_dir = stat(VERSION_TXT_DIR, &statbuf_dir);
+         if(rc_dir != 0 || statbuf_path.st_dev != statbuf_dir.st_dev) {
+            if(rc_dir != 0) {
+               parse_error_ = "Unable to stat <" VERSION_TXT_DIR ">";
+            } else {
+               parse_error_ = "version file is mounted";
+            }
+            ret_val = 1;
+         } else {
+            parse_version_contents = true;
+         }
+      }
+
+      if(parse_version_contents) {
          string contents((const char *)buffer);
          if(!rdk_version_value_get(contents, VERSION_TAG_IMAGENAME, &image_name_, "\r\n")) {
             parse_error_.append(VERSION_TAG_IMAGENAME);

--- a/src/rdkversion.cpp
+++ b/src/rdkversion.cpp
@@ -77,10 +77,9 @@ unsigned char rdk_version_parse_version(rdk_version_info_t *version_info) {
       ret_val = 1;
    } else {
       struct stat statbuf_path;
-      struct stat overlay_stat;
 
       int rc_path = stat(VERSION_TXT_PATH, &statbuf_path);
-      int rc_overlayfs_path = stat(OVERLAYFS_TAG_PATH, &overlay_stat);
+      gboolean overlayfs_enabled = g_file_test(OVERLAYFS_TAG_PATH, G_FILE_TEST_EXISTS);
 
       // The mounted file check is only needed when overlayfs is not enabled. If overlayfs is enabled, the check needs to be skipped.
       bool parse_version_contents = false;
@@ -88,7 +87,7 @@ unsigned char rdk_version_parse_version(rdk_version_info_t *version_info) {
       if(rc_path != 0) {
          parse_error_ = "Unable to stat <" VERSION_TXT_PATH ">";
          ret_val = 1;
-      } else if(rc_overlayfs_path == 0) {
+      } else if(overlayfs_enabled) {
          // skip mounted file check when overlayfs is enabled
          parse_version_contents = true;
       } else {


### PR DESCRIPTION
/version.txt would always come up as mounted in overlayfs enabled build.